### PR TITLE
fix: use flexbox layout to fix close button overlap and title truncation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -59,12 +59,15 @@ export default class AutoFitTabsPlugin extends Plugin {
         await this.saveData(this.settings);
         this.updateCSSVariables();
         
+        // Clear cached tab widths so all tabs recalculate with new settings
+        this.tabManager.clearCache();
+
         // If max width was disabled, completely reset all tabs
         const isMaxWidthChanged = previousMaxWidth > 0 && this.settings.maxWidth === 0;
         if (isMaxWidthChanged) {
             this.tabManager.resetTabs(isMaxWidthChanged);
         } else {
-            // Just recalculate normally for other setting changes
+            // Recalculate all tabs with updated settings
             this.tabManager.queueHeaderAdjustment();
         }
     }

--- a/src/tabManager.ts
+++ b/src/tabManager.ts
@@ -44,6 +44,10 @@ export class TabManager {
         });
     }
 
+    clearCache(): void {
+        this.tabWidthCache.clear();
+    }
+
     cleanup(): void {
         this.tabWidthCache.clear();
         if (this.observer) this.observer.disconnect();
@@ -558,18 +562,45 @@ export class TabManager {
         return titleElement?.textContent || '';
     }
 
+    private canvasContext: CanvasRenderingContext2D | null = null;
+
     private measureTextWidth(text: string, element: Element): number {
-        if (!this.measureElement) return 0;
-        
         const styles = window.getComputedStyle(element);
-        this.measureElement.style.font = styles.font;
-        this.measureElement.style.letterSpacing = styles.letterSpacing;
-        this.measureElement.style.textTransform = styles.textTransform;
-        this.measureElement.style.fontWeight = styles.fontWeight;
-        this.measureElement.textContent = text;
         
-        // Add a small padding buffer to ensure text fits
-        return Math.ceil(this.measureElement.offsetWidth) + 5;
+        let measuredWidth = 0;
+        try {
+            if (!this.canvasContext) {
+                const canvas = document.createElement('canvas');
+                this.canvasContext = canvas.getContext('2d');
+            }
+            if (this.canvasContext) {
+                const fontStyle = styles.fontStyle || 'normal';
+                const fontWeight = styles.fontWeight || 'normal';
+                const fontSize = styles.fontSize || '14px';
+                const fontFamily = styles.fontFamily || 'sans-serif';
+                this.canvasContext.font = `${fontStyle} ${fontWeight} ${fontSize} ${fontFamily}`;
+                if ('letterSpacing' in this.canvasContext && styles.letterSpacing && styles.letterSpacing !== 'normal') {
+                    (this.canvasContext as any).letterSpacing = styles.letterSpacing;
+                }
+                measuredWidth = this.canvasContext.measureText(text).width;
+            }
+        } catch {
+            measuredWidth = 0;
+        }
+
+        if ((!measuredWidth || measuredWidth === 0) && this.measureElement) {
+            this.measureElement.style.fontFamily = styles.fontFamily;
+            this.measureElement.style.fontSize = styles.fontSize;
+            this.measureElement.style.fontStyle = styles.fontStyle;
+            this.measureElement.style.fontWeight = styles.fontWeight;
+            this.measureElement.style.letterSpacing = styles.letterSpacing;
+            this.measureElement.style.textTransform = styles.textTransform;
+            this.measureElement.textContent = text;
+            measuredWidth = this.measureElement.getBoundingClientRect().width || this.measureElement.offsetWidth;
+        }
+        
+        // Add safety buffer (8px) to account for subpixel font rendering and padding
+        return Math.ceil(measuredWidth) + 8;
     }
 
     private calculateHeaderWidth(header: HTMLElement): number {
@@ -586,10 +617,10 @@ export class TabManager {
         const iconSpaceNeeded = this.plugin.settings.hideTabIcons ? 0 :
             (this.plugin.settings.iconWidth > 0 ? this.plugin.settings.iconWidth : 0);
 
-        // The close button element itself has a physical rendered width (~18px).
+        // The close button element itself has a physical rendered width (20px).
         // closeButtonLeftPadding is treated purely as a visual gap between the title
-        // text and the close button, so it can now be a small value (e.g. 6px).
-        const CLOSE_BUTTON_ELEMENT_WIDTH = 18;
+        // text and the close button, so it can now be a small value (e.g. 5-6px).
+        const CLOSE_BUTTON_ELEMENT_WIDTH = 20;
 
         const calculatedWidth = Math.ceil(Math.max(
             this.plugin.settings.leftPadding +
@@ -683,8 +714,6 @@ export class TabManager {
                 // Apply maxWidth class if the setting is enabled
                 if (this.plugin.settings.maxWidth > 0 && width >= this.plugin.settings.maxWidth) {
                     header.classList.add('autofit-max-width');
-                    const adjustedWidth = Math.min(width, this.plugin.settings.maxWidth + 20);
-                    header.style.setProperty('--header-width', `${adjustedWidth}px`);
                 } else {
                     header.classList.remove('autofit-max-width');
                 }

--- a/src/tabManager.ts
+++ b/src/tabManager.ts
@@ -585,12 +585,18 @@ export class TabManager {
         // When hideTabIcons is true or iconWidth is 0, don't reserve space for icons
         const iconSpaceNeeded = this.plugin.settings.hideTabIcons ? 0 :
             (this.plugin.settings.iconWidth > 0 ? this.plugin.settings.iconWidth : 0);
-            
+
+        // The close button element itself has a physical rendered width (~18px).
+        // closeButtonLeftPadding is treated purely as a visual gap between the title
+        // text and the close button, so it can now be a small value (e.g. 6px).
+        const CLOSE_BUTTON_ELEMENT_WIDTH = 18;
+
         const calculatedWidth = Math.ceil(Math.max(
             this.plugin.settings.leftPadding +
             iconSpaceNeeded +
             textWidth +
             this.plugin.settings.closeButtonLeftPadding +
+            CLOSE_BUTTON_ELEMENT_WIDTH +
             this.plugin.settings.closeButtonRightPadding,
             this.plugin.settings.minWidth
         ));

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface PluginSettings {
 export const DEFAULT_SETTINGS: PluginSettings = {
     minWidth: 40,
     leftPadding: 12,
-    closeButtonLeftPadding: 30,
+    closeButtonLeftPadding: 6,
     closeButtonRightPadding: 8,
     transitionDuration: 375,
     iconWidth: 20,

--- a/styles.css
+++ b/styles.css
@@ -123,17 +123,25 @@
 /* Title styles - fix structure especially when cleaning up max-width tabs */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner,
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-cleanup .workspace-tab-header-inner {
-    display: flex;
-    align-items: center;
-    width: 100%;
-    padding-left: var(--autofit-left-padding);
-    position: relative;
+    display: flex !important;
+    align-items: center !important;
+    width: 100% !important;
+    height: 100% !important;
+    box-sizing: border-box !important;
+    padding-left: var(--autofit-left-padding) !important;
+    padding-right: var(--autofit-close-button-right-padding, 8px) !important;
+    position: relative !important;
 }
 
+/* Title fills available space and truncates with ellipsis before the close button */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-title {
-    white-space: nowrap;
-    overflow: visible;
-    text-overflow: clip !important;
+    flex: 1 1 auto !important;
+    min-width: 0 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    padding-right: 0 !important;
+    margin-right: var(--autofit-close-button-left-padding, 6px) !important;
 }
 
 /* Icon styles - only for root content area */
@@ -171,16 +179,10 @@
     white-space: nowrap !important;
 }
 
-/* Styles for tabs with max-width setting - handle overflow and ensure spacing */
+/* Styles for tabs with max-width setting - overflow is handled by the flex layout */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-max-width .workspace-tab-header-inner-title {
     text-overflow: ellipsis !important;
     overflow: hidden !important;
-    max-width: calc(100% - var(--autofit-close-button-left-padding) - 8px);
-}
-
-/* Add padding-right to autofit tab titles to ensure space for close button */
-.workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-title {
-    padding-right: var(--autofit-close-button-left-padding);
 }
 
 
@@ -223,13 +225,15 @@
     z-index: 5; /* Ensure it stays above hidden tabs */
 }
 
-/* Fix position of close button to prevent jitter when icon width is 0 */
+/* Close button is an in-flow flex item, sits flush at the right edge naturally */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-close-button {
-    position: absolute;
-    right: 0;
-    top: 50%;
-    transform: translateY(-50%);
-    margin-right: var(--autofit-close-button-right-padding) !important;
+    flex: 0 0 auto !important;
+    position: static !important;
+    transform: none !important;
+    margin: 0 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
 }
 
 /* Hide tab icons when setting is enabled - only in main editor tabs */

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,9 @@
     width: var(--header-width) !important;
     min-width: var(--header-width) !important;
     max-width: var(--header-width) !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
     position: relative;
 }
 
@@ -125,27 +128,34 @@
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-cleanup .workspace-tab-header-inner {
     display: flex !important;
     align-items: center !important;
+    justify-content: flex-start !important;
     width: 100% !important;
     height: 100% !important;
     box-sizing: border-box !important;
+    padding: 0 !important;
     padding-left: var(--autofit-left-padding) !important;
     padding-right: var(--autofit-close-button-right-padding, 8px) !important;
+    margin: 0 !important;
     position: relative !important;
 }
 
-/* Title fills available space and truncates with ellipsis before the close button */
+/* Title sizes to fit text, can shrink with ellipsis, with close button directly adjacent */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-title {
-    flex: 1 1 auto !important;
+    flex: 0 1 auto !important;
     min-width: 0 !important;
+    max-width: 100% !important;
+    box-sizing: border-box !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    margin-right: var(--autofit-close-button-left-padding, 6px) !important;
     white-space: nowrap !important;
     overflow: hidden !important;
     text-overflow: ellipsis !important;
-    padding-right: 0 !important;
-    margin-right: var(--autofit-close-button-left-padding, 6px) !important;
 }
 
 /* Icon styles - only for root content area */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-icon {
+    flex: 0 0 auto !important;
     width: var(--autofit-icon-width);
     display: var(--autofit-icon-display, flex); /* Use flex by default, none when icon width is 0 */
     align-items: center;
@@ -227,13 +237,19 @@
 
 /* Close button is an in-flow flex item, sits flush at the right edge naturally */
 .workspace-split.mod-vertical.mod-root .workspace-tab-header.autofit-tab .workspace-tab-header-inner-close-button {
-    flex: 0 0 auto !important;
+    flex: 0 0 20px !important;
     position: static !important;
     transform: none !important;
+    padding: 0 !important;
     margin: 0 !important;
+    box-sizing: border-box !important;
     display: flex !important;
     align-items: center !important;
     justify-content: center !important;
+    width: 20px !important;
+    min-width: 20px !important;
+    max-width: 20px !important;
+    height: 20px !important;
 }
 
 /* Hide tab icons when setting is enabled - only in main editor tabs */


### PR DESCRIPTION
Thanks so much for this plug-in! It makes tabs look so much better and really improves the visual aesthetic of Obsidian.

I just wanted to bring to your attention something I've noticed -- in the current version of the plugin, long titles can overlap with the tab close (X) button when the left padding is set to a low value, which looks really awkward. When padding is set to a high value, then there can be a LOT of white space between the previous word and the close button. To prevent this, I made a couple tweaks locally to prevent this from happening and figured you might want to incorporate the logic? The following PR applies the changes I made/tested locally:

<img width="1034" height="210" alt="2026-08-11_10-44-56_Obsidian" src="https://github.com/user-attachments/assets/52e87481-e6c6-476e-a4d4-8446224dd756" />

## Problem

When `closeButtonLeftPadding` is set to a low value, the close button (`×`) visually overlaps the note title text. When set to a high value (e.g. the default 30px), tabs have excessive dead whitespace between the truncated title and the `×`.

**Root cause:** `closeButtonLeftPadding` was simultaneously serving three roles:
1. Visual gap before the `×`
2. The CSS padding-right budget reserved on the title element
3. A component of the JS tab width calculation

No single value satisfies all three requirements at once — low overlaps, high wastes space.

## Solution

Replace the absolutely-positioned close button with a native CSS flexbox layout:

- `.workspace-tab-header-inner` → flex container
- `.workspace-tab-header-inner-title` → `lex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis` — fills available space, truncates cleanly with `...` naturally
- `.workspace-tab-header-inner-close-button` → `lex: 0 0 auto; position: static` — sits at the right edge as an in-flow flex child, no `position: absolute` or `right: 0` needed

In `abManager.ts`, `calculateHeaderWidth()` now includes an explicit `CLOSE_BUTTON_ELEMENT_WIDTH = 18` constant for the physical button element. This means `closeButtonLeftPadding` is now solely responsible for the **visual gap** between the title text and the `×` button — a small value like 4–8px is sufficient.

## Changes

- `styles.css`: Flexbox layout for tab header inner; title is flex:1 with ellipsis; close button is static flex child
- `src/tabManager.ts`: `calculateHeaderWidth()` adds `CLOSE_BUTTON_ELEMENT_WIDTH = 18` to the width budget
- `src/types.ts`: `closeButtonLeftPadding` default reduced from `30` to `6`

## Result

Short titles → tight tab. Long titles → clean `...` truncation where the `X` begins. :)