### PR TITLE
fix: adjust close button padding defaults

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,8 +16,8 @@ export interface PluginSettings {
 export const DEFAULT_SETTINGS: PluginSettings = {
     minWidth: 40,
     leftPadding: 12,
-    closeButtonLeftPadding: 6,
-    closeButtonRightPadding: 8,
+    closeButtonLeftPadding: 0,
+    closeButtonRightPadding: 30,
     transitionDuration: 375,
     iconWidth: 20,
     maxWidth: 0, // 0 means disabled


### PR DESCRIPTION
Changes closeButtonLeftPadding default from 6 to 0 and closeButtonRightPadding default from 8 to 30.